### PR TITLE
Add http service discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,15 @@ To test the `exporter-filterproxy` in Kubernetes using the Kubernetes service di
 make kind
 ```
 
-This will start a local kind cluster and deploy a `exporter-filterproxy` that proxies the metrics of the CoreDNS service.
+This will start a local kind cluster and deploy a `exporter-filterproxy` that proxies the metrics of the CoreDNS service, as well as a Prometheus instance.
+
+Once the cluster started you can expose the test Prometheus using port-forward
+
+```
+kubectl port-forward svc/prometheus 9090
+```
+
+You should see two discovered targets through the exporter-filterproxy when you open `http://localhost:9090/targets`
 
 
 ## Configuration

--- a/discovery.go
+++ b/discovery.go
@@ -1,0 +1,29 @@
+package main
+
+import (
+	"context"
+	"log"
+
+	"github.com/vshn/exporter-filterproxy/target"
+)
+
+type targetConfigFetcher interface {
+	FetchTargetConfigs(ctx context.Context, baseTarget string, basePath string) ([]target.StaticConfig, error)
+}
+
+type multiTargetConfigFetcher map[string]targetConfigFetcher
+
+func (mf multiTargetConfigFetcher) FetchTargetConfigs(ctx context.Context, baseTarget string, basePath string) ([]target.StaticConfig, error) {
+
+	configs := []target.StaticConfig{}
+	for path, f := range mf {
+		c, err := f.FetchTargetConfigs(ctx, baseTarget, basePath+path)
+		if err != nil {
+			log.Printf("Failed to fetch targets: %s", err.Error())
+			continue
+		}
+		configs = append(configs, c...)
+	}
+
+	return configs, nil
+}

--- a/discovery_test.go
+++ b/discovery_test.go
@@ -1,0 +1,86 @@
+package main
+
+import (
+	"context"
+	"testing"
+
+	"github.com/prometheus/common/model"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/vshn/exporter-filterproxy/target"
+)
+
+func TestMultiTargetConfigFetcher(t *testing.T) {
+
+	fa := fakeTargetConfigFetcher{
+		t:      t,
+		path:   "/a",
+		target: "proxy.example.com",
+		configs: []target.StaticConfig{
+			{
+				Targets: []string{"proxy.example.com"},
+				Labels: map[model.LabelName]model.LabelValue{
+					"foo": "a1",
+				},
+			},
+			{
+				Targets: []string{"proxy.example.com"},
+				Labels: map[model.LabelName]model.LabelValue{
+					"foo": "a2",
+				},
+			},
+		},
+	}
+	fb := fakeTargetConfigFetcher{
+		t:      t,
+		path:   "/b",
+		target: "proxy.example.com",
+		configs: []target.StaticConfig{
+			{
+				Targets: []string{"proxy.example.com"},
+				Labels: map[model.LabelName]model.LabelValue{
+					"foo": "b1",
+				},
+			},
+			{
+				Targets: []string{"proxy.example.com"},
+				Labels: map[model.LabelName]model.LabelValue{
+					"foo": "b2",
+				},
+			},
+		},
+	}
+
+	mf := multiTargetConfigFetcher{
+		"/a": fa,
+		"/b": fb,
+	}
+
+	conf, err := mf.FetchTargetConfigs(context.TODO(), "proxy.example.com", "")
+	require.NoError(t, err)
+	require.Len(t, conf, 4)
+
+	seenFoolabels := []string{}
+	for _, c := range conf {
+		require.Len(t, c.Targets, 1)
+		assert.Equal(t, "proxy.example.com", c.Targets[0])
+		require.Len(t, c.Labels, 1)
+
+		seenFoolabels = append(seenFoolabels, string(c.Labels["foo"]))
+	}
+	assert.ElementsMatch(t, seenFoolabels, []string{"b1", "b2", "a1", "a2"})
+
+}
+
+type fakeTargetConfigFetcher struct {
+	configs []target.StaticConfig
+	t       *testing.T
+	path    string
+	target  string
+}
+
+func (f fakeTargetConfigFetcher) FetchTargetConfigs(ctx context.Context, baseTarget string, basePath string) ([]target.StaticConfig, error) {
+	assert.Equal(f.t, f.path, basePath)
+	assert.Equal(f.t, f.target, baseTarget)
+	return f.configs, nil
+}

--- a/handle.go
+++ b/handle.go
@@ -71,7 +71,6 @@ func multiHandler(prefix string, fetcher multiMetricsFetcher) http.HandlerFunc {
 func serviceDiscoveryHandler(prefix string, fetcher targetConfigFetcher) http.HandlerFunc {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 
-		log.Printf("Call SD to %s\n", r.URL.Path)
 		configs, err := fetcher.FetchTargetConfigs(r.Context(), r.Host, strings.TrimSuffix(r.URL.Path, "/"))
 		if err != nil {
 			log.Printf("Failed to discover Endpoints: %s", err.Error())

--- a/sample-config/prometheus.yml
+++ b/sample-config/prometheus.yml
@@ -5,10 +5,7 @@ global:
 
 
 scrape_configs:
-  - job_name: 'node-cpu-2'
-    metrics_path: /node
-    params:
-      cpu: ['2']
-    static_configs:
-      - targets: ['filterproxy:8082']
+  - job_name: 'exporter-filterproxy'
+    http_sd_configs:
+      - url: 'http://filterproxy:8082'
 

--- a/target/static.go
+++ b/target/static.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	dto "github.com/prometheus/client_model/go"
+	"github.com/prometheus/common/model"
 )
 
 type StaticFetcher struct {
@@ -56,6 +57,19 @@ func (f *StaticFetcher) FetchMetrics(_ context.Context) ([]dto.MetricFamily, err
 	f.cache = metrics
 	f.lastUpdated = f.now()
 	return metrics, nil
+}
+
+func (*StaticFetcher) FetchTargetConfigs(ctx context.Context, baseTarget string, basePath string) ([]StaticConfig, error) {
+
+	conf := StaticConfig{
+		Targets: []string{baseTarget},
+		Labels: map[model.LabelName]model.LabelValue{
+			"__metrics_path__": model.LabelValue(basePath),
+			"metrics_path":     model.LabelValue(basePath),
+		},
+	}
+
+	return []StaticConfig{conf}, nil
 }
 
 func (f *StaticFetcher) now() time.Time {

--- a/target/static_test.go
+++ b/target/static_test.go
@@ -132,3 +132,18 @@ func TestFetchError(t *testing.T) {
 	_, err := f.FetchMetrics(context.TODO())
 	require.Error(t, err)
 }
+
+func TestFetchTargetConfigs(t *testing.T) {
+
+	f := NewStaticFetcher("http://foobar.example.com/buzz", "", time.Second, false)
+
+	tconfs, err := f.FetchTargetConfigs(context.TODO(), "proxy.example.com", "/buzz")
+	require.NoError(t, err)
+	require.Len(t, tconfs, 1)
+	tconf := tconfs[0]
+	require.Len(t, tconf.Targets, 1)
+	assert.Equal(t, "proxy.example.com", tconf.Targets[0])
+	assert.Len(t, tconf.Labels, 2)
+	assert.EqualValues(t, "/buzz", tconf.Labels["__metrics_path__"])
+	assert.EqualValues(t, "/buzz", tconf.Labels["metrics_path"])
+}

--- a/target/target.go
+++ b/target/target.go
@@ -7,7 +7,13 @@ import (
 
 	dto "github.com/prometheus/client_model/go"
 	"github.com/prometheus/common/expfmt"
+	"github.com/prometheus/common/model"
 )
+
+type StaticConfig struct {
+	Targets []string       `json:"targets"`
+	Labels  model.LabelSet `json:"labels"`
+}
 
 func fetchMetrics(client *http.Client, url string, authToken string) ([]dto.MetricFamily, error) {
 	req, err := http.NewRequest(http.MethodGet, url, nil)

--- a/test/manifest/prometheus.yaml
+++ b/test/manifest/prometheus.yaml
@@ -1,0 +1,127 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: prometheus
+  labels:
+    app: prometheus-deployment
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 500Mi
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: prometheus
+rules:
+- apiGroups: [""]
+  resources:
+  - nodes
+  - services
+  - endpoints
+  - pods
+  verbs: ["get", "list", "watch"]
+- apiGroups:
+  - extensions
+  resources:
+  - ingresses
+  verbs: ["get", "list", "watch"]
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: prometheus
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: prometheus
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: prometheus
+subjects:
+- kind: ServiceAccount
+  name: prometheus
+  namespace: default
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: prometheus-config
+data:
+  prometheus.yml: |
+    global:
+      scrape_interval:     15s
+      evaluation_interval: 15s
+
+    scrape_configs:
+      - job_name: 'prometheus'
+        static_configs:
+        - targets: ['localhost:9090']
+      - job_name: 'proxy'
+        http_sd_configs:
+        - url: "http://exporter-filterproxy:80"
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: prometheus
+  labels:
+    app: prometheus
+spec:
+  replicas: 1
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 1
+    type: RollingUpdate
+  selector:
+    matchLabels:
+      app: prometheus
+  template:
+    metadata:
+      labels:
+        app: prometheus
+    spec:
+      containers:
+      - name: prometheus
+        image: prom/prometheus
+        args:
+          - '--storage.tsdb.retention=6h'
+          - '--storage.tsdb.path=/prometheus'
+          - '--config.file=/etc/prometheus/prometheus.yml'
+        ports:
+        - name: web
+          containerPort: 9090
+        volumeMounts:
+        - name: prometheus-config-volume
+          mountPath: /etc/prometheus
+        - name: prometheus-storage-volume
+          mountPath: /prometheus
+      restartPolicy: Always
+      volumes:
+      - name: prometheus-config-volume
+        configMap:
+            defaultMode: 420
+            name: prometheus-config
+      - name: prometheus-storage-volume
+        persistentVolumeClaim:
+            claimName: prometheus
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: prometheus
+spec:
+  ports:
+  - name: http
+    port: 9090
+    protocol: TCP
+    targetPort: 9090
+  selector:
+    app: prometheus
+  type: ClusterIP


### PR DESCRIPTION
This PR makes the k8s endpoints exposed in #4 actually discoverable through [HTTP service discovery](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#http_sd_config)

We add a `FetchTargetConfigs` to the metrics fetcher and return scrape configs for all endpoint on `/`

## Checklist

- [x] The PR has a meaningful title. It will be used to auto generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Update the documentation.
- [x] Link this PR to related issues or PRs.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
